### PR TITLE
feat: publish bilingual graduation timeline

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -147,6 +147,12 @@ const publicationsCollection = defineCollection({
         venue:   z.string(),
         year:    z.number(),
         link:    z.string().url().optional(),
+        destination: z.enum(["DataSys", "SAGE"]),
+        destination_url: z.string().url(),
+        status_en: z.string(),
+        status_zh: z.string(),
+        summary_en: z.string(),
+        summary_zh: z.string(),
       })
     ),
   }),

--- a/src/content/publications/-index.md
+++ b/src/content/publications/-index.md
@@ -1,106 +1,193 @@
 ---
-title: "成果发布"
-description: "IntelliStream 代表性论文与近年成果"
+title: "Graduated Publications"
+description: "Formally published work from projects that graduated from the IntelliStream incubator"
 draft: false
 
 publications:
+  - name: "SAGE: A Dataflow-Native Framework for Modular, Controllable, and Transparent LLM-Augmented Reasoning"
+    authors: "Jun Liu, Peilin Liu, Ruicheng Zhang, Senlei Zhang, Yanbo Chen, Ziao Wang, Jinyun Yang, Mingqi Wang, Shuhao Zhang, Xiaofei Liao, Hai Jin"
+    venue: "ICML 2026"
+    year: 2026
+    destination: "SAGE"
+    destination_url: "https://sage.org.ai/achievements/"
+    status_en: "Published"
+    status_zh: "已发表"
+    summary_en: "A dataflow-native framework for modular, controllable, and transparent LLM-augmented reasoning."
+    summary_zh: "面向模块化、可控和透明大模型增强推理的数据流原生框架。"
+
+  - name: "Neuromem: A Granular Decomposition of the Streaming Lifecycle in External Memory for LLMs"
+    authors: "Ruicheng Zhang, Xinyi Li, Tianyi Xu, Shuhao Zhang, Xiaofei Liao, Hai Jin"
+    venue: "ICML 2026"
+    year: 2026
+    destination: "SAGE"
+    destination_url: "https://sage.org.ai/achievements/"
+    status_en: "Published"
+    status_zh: "已发表"
+    summary_en: "A granular lifecycle model for external memory in long-running LLM applications."
+    summary_zh: "面向长时运行大模型应用外部记忆的细粒度生命周期模型。"
+
   - name: "FlowRAG: Continual Learning for Dynamic Retriever in Retrieval-Augmented Generation"
     authors: "Senlei Zhang, Tongjun Shi, Dandan Song, Luan Zhang, Shuhao Zhang, Xiaofei Liao, Hai Jin"
-    venue: "WWW"
+    venue: "WWW 2026"
     year: 2026
+    destination: "SAGE"
+    destination_url: "https://sage.org.ai/achievements/"
+    status_en: "Published"
+    status_zh: "已发表"
+    summary_en: "Continual retriever adaptation for retrieval-augmented generation over evolving corpora."
+    summary_zh: "面向持续演化语料库的 RAG 检索器持续适应方法。"
 
   - name: "StreamFP: Fingerprint-guided Data Selection for Efficient Stream Learning"
     authors: "Changwu Li, Tongjun Shi, Shuhao Zhang, Binbin Chen, Bingsheng He, Xiaofei Liao, Hai Jin"
-    venue: "WWW"
+    venue: "WWW 2026"
     year: 2026
+    destination: "DataSys"
+    destination_url: "https://datasys.sage.org.ai/achievements.html"
+    status_en: "Published"
+    status_zh: "已发表"
+    summary_en: "Model fingerprints guide efficient data selection and buffer updates over evolving streams."
+    summary_zh: "利用模型指纹指导持续演化数据流上的高效数据选择与缓冲更新。"
 
   - name: "GRACE: Alleviating Reconstruction Cost in Dynamic Graph Processing Systems"
     authors: "Hongru Gao, Shuhao Zhang, Xiaofei Liao, Hai Jin"
-    venue: "ICDE"
+    venue: "ICDE 2026"
     year: 2026
+    destination: "DataSys"
+    destination_url: "https://datasys.sage.org.ai/achievements.html"
+    status_en: "Published"
+    status_zh: "已发表"
+    summary_en: "Property-guided reservation and rebalancing reduce reconstruction cost in dynamic graph systems."
+    summary_zh: "通过属性引导的预留与重平衡降低动态图系统的重构开销。"
 
   - name: "CANDOR-Bench: Benchmarking In-Memory Continuous ANNS under Dynamic Open-World Streams"
-    authors: "Mingqi Wang, Junyao Dong, Jun Liu, Ruicheng Zhang, Jianjun Zhao, Ruipeng Wan, Xinyan Lei, Shuhao Zhang, Bolong Zheng, Haikun Liu, Xiaofei Liao, Hai Jin"
-    venue: "SIGMOD"
+    authors: "Mingqi Wang, Jun Liu, Ruicheng Zhang, Jianjun Zhao, Ruipeng Wan, Xinyan Lei, Shuhao Zhang, Bolong Zheng, Haikun Liu, Xiaofei Liao, Hai Jin"
+    venue: "SIGMOD 2026"
     year: 2026
-
-  - name: "Select Edges Wisely: Monotonic Path Aware Graph Layout Optimization for Disk-Based ANN Search"
-    authors: "Ziyang Yue, Bolong Zheng, Ling Xu, Kanru Xu, Shuhao Zhang, Yajuan Du, Yunjun Gao, Xiaofang Zhou, Christian S. Jensen"
-    venue: "SIGMOD"
-    year: 2026
+    destination: "DataSys"
+    destination_url: "https://datasys.sage.org.ai/achievements.html"
+    status_en: "Published"
+    status_zh: "已发表"
+    summary_en: "A continuous ANNS benchmark for dynamic open-world vector streams."
+    summary_zh: "面向动态开放世界向量流的连续 ANNS 评测基准。"
 
   - name: "Scalable Transactional Stream Processing on Multicore Processors"
     authors: "Jianjun Zhao, Yancan Mao, Zhonghao Yang, Haikun Liu, Shuhao Zhang"
-    venue: "TKDE"
+    venue: "TKDE 2025"
     year: 2025
+    destination: "DataSys"
+    destination_url: "https://datasys.sage.org.ai/achievements.html"
+    status_en: "Published"
+    status_zh: "已发表"
+    summary_en: "The journal extension of MorphStream for generalized windows and non-deterministic state access."
+    summary_zh: "支持通用窗口与非确定性状态访问的 MorphStream 期刊扩展。"
 
-  - name: "A Framework of Knowledge Graph-Enhanced Large Language Model Based on Global Planning"
-    authors: "Yading Li, Dandan Song, Yuhang Tian, Hao Wang, Changzhi Zhou, Shuhao Zhang"
-    venue: "TKDE"
+  - name: "Scalable Machine Learning for Real-Time Fault Diagnosis in Industrial IoT Cooling Roller Systems"
+    authors: "Dandan Zhao, Karthick Sharma, Yuxin Qi, Qixun Liu, Shuhao Zhang"
+    venue: "ICDE 2025"
     year: 2025
-
-  - name: "Ferret: An Efficient Online Continual Learning Framework under Varying Memory Constraints"
-    authors: "Yuhao Zhou, Yuxin Tian, Jindi Lv, Mingjia Shi, Yuanxi Li, Qing Ye, Shuhao Zhang, Jiancheng Lv"
-    venue: "CVPR"
-    year: 2025
-
-  - name: "Detecting Hallucination in Large Language Models through Deep Internal Representation Analysis"
-    authors: "Luan Zhang, Dandan Song, Zhijing Wu, Yuhang Tian, Changzhi Zhou, Jing Xu, Ziyi Yang, Shuhao Zhang"
-    venue: "IJCAI"
-    year: 2025
+    destination: "DataSys"
+    destination_url: "https://datasys.sage.org.ai/achievements.html"
+    status_en: "Published"
+    status_zh: "已发表"
+    summary_en: "SRTFD scales real-time fault diagnosis over high-velocity industrial streams."
+    summary_zh: "SRTFD 面向高速工业数据流扩展实时故障诊断。"
 
   - name: "CStream: Parallel Data Stream Compression on Multicore Edge Devices"
     authors: "Xianzhi Zeng, Shuhao Zhang"
-    venue: "TKDE"
+    venue: "TKDE 2024"
     year: 2024
+    destination: "DataSys"
+    destination_url: "https://datasys.sage.org.ai/achievements.html"
+    status_en: "Published"
+    status_zh: "已发表"
+    summary_en: "Hardware-conscious parallel stream compression for multicore edge systems."
+    summary_zh: "面向多核边缘系统的硬件感知并行流压缩。"
 
   - name: "PECJ: Stream Window Join on Disorder Data Streams with Proactive Error Compensation"
     authors: "Xianzhi Zeng, Shuhao Zhang, Hongbin Zhong, Hao Zhang, Mian Lu, Zhao Zheng, Yuqiang Chen"
-    venue: "SIGMOD"
+    venue: "SIGMOD 2024"
     year: 2024
+    destination: "DataSys"
+    destination_url: "https://datasys.sage.org.ai/achievements.html"
+    status_en: "Published"
+    status_zh: "已发表"
+    summary_en: "Proactive error compensation for accurate, low-latency joins over out-of-order streams."
+    summary_zh: "通过主动误差补偿实现准确、低延迟的乱序流连接。"
 
   - name: "LibAMM: Empirical Insights into Approximate Computing for Accelerating Matrix Multiplication"
     authors: "Xianzhi Zeng, Wenchao Jiang, Shuhao Zhang"
-    venue: "NeurIPS"
+    venue: "NeurIPS 2024"
     year: 2024
+    destination: "DataSys"
+    destination_url: "https://datasys.sage.org.ai/achievements.html"
+    status_en: "Published"
+    status_zh: "已发表"
+    summary_en: "An empirical study and benchmark suite for approximate matrix multiplication."
+    summary_zh: "面向近似矩阵乘的实证研究与基准套件。"
+
+  - name: "MOStream: A Modular and Self-Optimizing Data Stream Clustering Algorithm"
+    authors: "Zhengru Wang, Xin Wang, Shuhao Zhang"
+    venue: "ICDM 2024"
+    year: 2024
+    destination: "DataSys"
+    destination_url: "https://datasys.sage.org.ai/achievements.html"
+    status_en: "Published"
+    status_zh: "已发表"
+    summary_en: "A modular stream-clustering method that adapts its core design choices at runtime."
+    summary_zh: "在运行时自适应核心设计选择的模块化流聚类方法。"
+
+  - name: "MorphStream: Scalable Processing of Transactions over Streams"
+    authors: "Siqi Xiang, Zhonghao Yang, Jianjun Zhao, Yancan Mao, Shuhao Zhang"
+    venue: "ICDE 2024 Demo"
+    year: 2024
+    destination: "DataSys"
+    destination_url: "https://datasys.sage.org.ai/achievements.html"
+    status_en: "Published demo"
+    status_zh: "已发表演示"
+    summary_en: "A system demonstration of adaptive transactional processing over streams."
+    summary_zh: "面向流上自适应事务处理的系统演示。"
 
   - name: "MorphStream: Adaptive Scheduling for Scalable Transactional Stream Processing on Multicores"
     authors: "Yancan Mao, Jianjun Zhao, Shuhao Zhang, Haikun Liu, Volker Markl"
-    venue: "SIGMOD"
+    venue: "SIGMOD 2023"
     year: 2023
-
-  - name: "A Survey on Transactional Stream Processing"
-    authors: "Shuhao Zhang, Juan Soto, Volker Markl"
-    venue: "VLDB Journal"
-    year: 2023
+    destination: "DataSys"
+    destination_url: "https://datasys.sage.org.ai/achievements.html"
+    status_en: "Published"
+    status_zh: "已发表"
+    summary_en: "Adaptive scheduling for scalable transaction processing over dynamic streaming workloads."
+    summary_zh: "面向动态流工作负载的可扩展事务处理与自适应调度。"
 
   - name: "Data Stream Clustering: An In-depth Empirical Study"
     authors: "Xin Wang, Zhengru Wang, Zhenyu Wu, Shuhao Zhang, Xuanhua Shi, Li Lu"
-    venue: "SIGMOD"
+    venue: "SIGMOD 2023"
     year: 2023
+    destination: "DataSys"
+    destination_url: "https://datasys.sage.org.ai/achievements.html"
+    status_en: "Published"
+    status_zh: "已发表"
+    summary_en: "A systematic benchmark of representative data-stream clustering algorithms."
+    summary_zh: "对代表性数据流聚类算法开展系统评测。"
 
   - name: "SentiStream: A Co-Training Framework for Adaptive Online Sentiment Analysis in Evolving Data Streams"
     authors: "Yuhao Wu, Karthick Sharma, Chun Wei Seah, Shuhao Zhang"
-    venue: "EMNLP"
+    venue: "EMNLP 2023"
     year: 2023
+    destination: "DataSys"
+    destination_url: "https://datasys.sage.org.ai/achievements.html"
+    status_en: "Published"
+    status_zh: "已发表"
+    summary_en: "Adaptive co-training for online sentiment analysis in evolving streams."
+    summary_zh: "面向持续演化数据流在线情感分析的自适应协同训练。"
 
-  - name: "Parallelizing Intra-Window Join on Multicores: An Experimental Study"
-    authors: "Shuhao Zhang, Yancan Mao, Jiong He, Philipp M. Grulich, Steffen Zeuch, Bingsheng He, Richard T. B. Ma, Volker Markl"
-    venue: "SIGMOD"
-    year: 2021
-
-  - name: "BriskStream: Scaling Data Stream Processing on Shared-Memory Multicore Architectures"
-    authors: "Shuhao Zhang, Jiong He, Amelie Chi Zhou, Bingsheng He"
-    venue: "SIGMOD"
-    year: 2019
-
-  - name: "Towards Concurrent Stateful Stream Processing on Multicore Processors"
-    authors: "Shuhao Zhang, Yingjun Wu, Feng Zhang, Bingsheng He"
-    venue: "ICDE"
-    year: 2020
-
-  - name: "FineStream: Fine-Grained Window-Based Stream Processing on CPU-GPU Integrated Architectures"
-    authors: "Feng Zhang, Lin Yang, Shuhao Zhang, Bingsheng He, Wei Lu, Xiaoyong Du"
-    venue: "USENIX ATC"
-    year: 2020
+  - name: "Parallelizing Stream Compression for IoT Applications on Asymmetric Multicores"
+    authors: "Xianzhi Zeng, Shuhao Zhang"
+    venue: "ICDE 2023"
+    year: 2023
+    destination: "DataSys"
+    destination_url: "https://datasys.sage.org.ai/achievements.html"
+    status_en: "Published"
+    status_zh: "已发表"
+    summary_en: "Fine-grained decomposition and asymmetry-aware scheduling for energy-efficient stream compression."
+    summary_zh: "通过细粒度分解与非对称感知调度实现高能效流压缩。"
 ---

--- a/src/pages/pub.astro
+++ b/src/pages/pub.astro
@@ -1,71 +1,111 @@
 ---
 import Base from "@/layouts/Base.astro";
-import { markdownify } from "@/lib/utils/textConverter";
 import type { CollectionEntry } from "astro:content";
 import { getEntry } from "astro:content";
 
-const entry = await getEntry(
-  "publications",
-  "-index"
-) as CollectionEntry<"publications">;
-
-const { title, description, publications } = entry.data;
-
-// 只保留带 year 字段的条目，按 year 降序，取前 10 条
-const recent = publications
-  .filter(p => typeof p.year === "number")
-  .sort((a, b) => b.year - a.year)
-  .slice(0, 10);
-
-// 学术主页链接
-const scholarUrl = "https://shuhaozhangtony.github.io/";
+const entry = await getEntry("publications", "-index") as CollectionEntry<"publications">;
+const publications = [...entry.data.publications].sort((a, b) => b.year - a.year);
+const years = [...new Set(publications.map((publication) => publication.year))];
 ---
-<Base title={title} description={description}>
-  <section class="section">
+<Base title="Graduated Publications" description="Published work from projects graduated through the IntelliStream incubator">
+  <section class="publication-page section">
     <div class="container">
-      <h1 class="text-center font-normal" set:html={markdownify(title)} />
+      <header class="publication-hero">
+        <div>
+          <span data-en="INCUBATOR OUTPUT" data-zh="孵化成果">孵化成果</span>
+          <h1 data-en="Graduated Publications" data-zh="毕业项目发表成果">毕业项目发表成果</h1>
+          <p data-en="Formally published work from projects that matured in IntelliStream and graduated to DataSys or SAGE." data-zh="在 IntelliStream 中成熟并毕业至 DataSys 或 SAGE 项目的正式发表成果。">在 IntelliStream 中成熟并毕业至 DataSys 或 SAGE 项目的正式发表成果。</p>
+        </div>
+        <button id="publication-language-toggle" type="button" aria-label="Switch to English">EN</button>
+      </header>
 
-      <ul class="mt-8 space-y-6">
-        {recent.map(item => (
-          <li class="border-b pb-4">
-            {/* Title */}
-            <h3 class="text-lg font-semibold">
-              <a
-                href={item.link || "#"}
-                target="_blank"
-                rel="noopener"
-                class="hover:underline"
-              >
-                {item.name}
-              </a>
-            </h3>
-            {/* Authors */}
-            <p class="text-sm text-gray-600 mt-1">
-              {item.authors}
-            </p>
-            {/* Venue */}
-            <p class="text-sm text-gray-600">
-              {item.venue}
-            </p>
-            {/* Year */}
-            <p class="text-sm text-gray-600">
-              {item.year}
-            </p>
-          </li>
+      <p class="publication-policy" data-en="Only accepted or published work with a clear graduated project boundary is listed. Incubating and submission-stage work remains off this page." data-zh="本页只列出已正式接收或发表且毕业边界明确的成果；孵化中和投稿阶段工作不列入。">本页只列出已正式接收或发表且毕业边界明确的成果；孵化中和投稿阶段工作不列入。</p>
+
+      <nav class="publication-release-line" aria-label="成果发布线">
+        {years.map((year) => {
+          const count = publications.filter((publication) => publication.year === year).length;
+          return <a href={`#year-${year}`}><span>{year}</span><strong>{count}</strong><small data-en="publications" data-zh="项成果">项成果</small></a>;
+        })}
+      </nav>
+
+      <div class="publication-years">
+        {years.map((year) => (
+          <section id={`year-${year}`} class="publication-year">
+            <div class="publication-year-head">
+              <span>{year}</span>
+              <h2 data-en="Graduated work" data-zh="毕业成果">毕业成果</h2>
+            </div>
+            <div class="publication-list">
+              {publications.filter((publication) => publication.year === year).map((publication) => (
+                <article class="publication-entry">
+                  <div class="publication-meta">{publication.venue}</div>
+                  <div class="publication-copy">
+                    <h3>{publication.name}</h3>
+                    <p><strong>{publication.authors}</strong></p>
+                    <p data-en={publication.summary_en} data-zh={publication.summary_zh}>{publication.summary_zh}</p>
+                    <a href={publication.destination_url}>
+                      <span data-en="Graduated to" data-zh="毕业至">毕业至</span> {publication.destination} ↗
+                    </a>
+                  </div>
+                  <div class={`publication-destination destination-${publication.destination.toLowerCase()}`}>
+                    <span>{publication.destination}</span>
+                    <small data-en={publication.status_en} data-zh={publication.status_zh}>{publication.status_zh}</small>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </section>
         ))}
-      </ul>
-
-      <div class="text-center mt-8">
-        <a
-          href={scholarUrl}
-          target="_blank"
-          rel="noopener"
-          class="btn btn-secondary"
-        >
-          更多
-        </a>
       </div>
     </div>
   </section>
 </Base>
 
+<style>
+  .publication-page{--ink:#101818;--muted:#60706e;--line:#cbd5d1;--paper:#f2f6f3;color:var(--ink)}
+  .publication-hero{display:flex;align-items:end;justify-content:space-between;gap:28px;padding:42px 0 28px;border-bottom:1px solid var(--line)}
+  .publication-hero>div>span{color:#147275;font:700 12px ui-monospace,SFMono-Regular,Menlo,monospace}
+  .publication-hero h1{margin:9px 0 12px;font-size:54px;line-height:1}
+  .publication-hero p{max-width:760px;margin:0;color:var(--muted);font-size:17px}
+  #publication-language-toggle{min-height:40px;padding:8px 14px;border:1px solid var(--ink);border-radius:4px;color:#fff;background:var(--ink);font-weight:800;cursor:pointer}
+  #publication-language-toggle:hover,#publication-language-toggle:focus-visible{color:var(--ink);background:#dfeebf}
+  .publication-policy{margin:24px 0 0;padding:16px 18px;border-left:4px solid #d5a72c;color:var(--muted);background:var(--paper)}
+  .publication-release-line{margin:40px 0 66px;display:grid;grid-template-columns:repeat(4,minmax(0,1fr));border-top:1px solid var(--line);border-left:1px solid var(--line)}
+  .publication-release-line a{min-height:118px;padding:20px;display:grid;align-content:center;gap:3px;border-right:1px solid var(--line);border-bottom:1px solid var(--line);color:var(--ink);text-decoration:none}
+  .publication-release-line a:hover{background:var(--paper)}
+  .publication-release-line span{color:var(--muted);font:12px ui-monospace,SFMono-Regular,Menlo,monospace}
+  .publication-release-line strong{font-size:30px}.publication-release-line small{color:var(--muted)}
+  .publication-year{scroll-margin-top:90px}.publication-year+.publication-year{margin-top:78px}
+  .publication-year-head{display:grid;grid-template-columns:150px minmax(0,1fr);gap:28px;align-items:end;margin-bottom:14px}
+  .publication-year-head>span{color:#147275;font:700 22px ui-monospace,SFMono-Regular,Menlo,monospace}
+  .publication-year-head h2{margin:0;font-size:30px}
+  .publication-list{border-bottom:1px solid var(--line)}
+  .publication-entry{display:grid;grid-template-columns:150px minmax(0,1fr) 140px;gap:28px;padding:30px 0;border-top:1px solid var(--line)}
+  .publication-meta{color:var(--muted);font:12px ui-monospace,SFMono-Regular,Menlo,monospace;text-transform:uppercase}
+  .publication-copy h3{margin:0 0 12px;font-size:25px;line-height:1.18}.publication-copy p{margin:8px 0;color:var(--muted)}
+  .publication-copy a{font-weight:800;text-decoration:underline;text-underline-offset:4px}
+  .publication-destination{align-self:start;justify-self:end;min-width:112px;padding:9px;border-radius:3px;display:grid;gap:3px}
+  .publication-destination span{font-weight:850}.publication-destination small{font-size:10px;text-transform:uppercase}
+  .destination-datasys{color:#34560c;background:#dfeebf}.destination-sage{color:#105456;background:#c9e8e7}
+  @media(max-width:720px){.publication-hero{align-items:flex-start;flex-direction:column}.publication-hero h1{font-size:40px}.publication-release-line{grid-template-columns:repeat(2,minmax(0,1fr))}.publication-year-head,.publication-entry{grid-template-columns:1fr}.publication-entry{gap:10px}.publication-destination{justify-self:start}.publication-copy h3{font-size:21px;overflow-wrap:anywhere}}
+</style>
+
+<script is:inline>
+  (() => {
+    const key = "intellistream-publication-language";
+    const button = document.getElementById("publication-language-toggle");
+    const setLanguage = (language) => {
+      const selected = language === "en" ? "en" : "zh";
+      document.documentElement.lang = selected === "zh" ? "zh-CN" : "en";
+      document.querySelectorAll(".publication-page [data-en][data-zh]").forEach((node) => {
+        node.textContent = node.dataset[selected];
+      });
+      button.textContent = selected === "zh" ? "EN" : "中文";
+      button.setAttribute("aria-label", selected === "zh" ? "Switch to English" : "切换为中文");
+      document.querySelector(".publication-release-line").setAttribute("aria-label", selected === "zh" ? "成果发布线" : "Publication timeline");
+      localStorage.setItem(key, selected);
+    };
+    button.addEventListener("click", () => setLanguage(document.documentElement.lang.startsWith("zh") ? "en" : "zh"));
+    setLanguage(localStorage.getItem(key) || "zh");
+  })();
+</script>


### PR DESCRIPTION
Reframe the publications page as a bilingual timeline of formally published output from graduated projects.